### PR TITLE
Added ZingMp3 beta keys

### DIFF
--- a/extension/keysocket-zing-mp3-beta.js
+++ b/extension/keysocket-zing-mp3-beta.js
@@ -1,0 +1,6 @@
+keySocket.init("zing-mp3-beta-player", {
+  "play-pause": "div.z-miniplayer-controls > a.z-btn-play",
+  prev: "div.z-miniplayer-controls > a.z-btn-previous",
+  next: "div.z-miniplayer-controls > a.z-btn-next"
+  // stop is omitted
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -65,6 +65,10 @@
       "js": ["plugin-api.js", "keysocket-zing-mp3.js"]
     },
     {
+      "matches": ["*://beta.mp3.zing.vn/*"],
+      "js": ["plugin-api.js", "keysocket-zing-mp3-beta.js"]
+    },
+    {
       "matches": ["*://8tracks.com/*"],
       "js": ["plugin-api.js", "keysocket-eighttracks.js"]
     },


### PR DESCRIPTION
ZingMP3 has a beta site at https://beta.mp3.zing.vn with different css classes for media buttons.

## Description

I added `extension/keysocket-zing-mp3-beta.js` for new key maps

## How Has This Been Tested?

I built this extension using `grunt` and used Developer mode of chrome extensions to test this on https://beta.mp3.zing.vn and everything worked well.

## Types of changes
- [x ] New feature (supports beta.mp3.zing.vn)